### PR TITLE
Use official snapcraft Docker file as basis for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,56 @@
-FROM ubuntu:18.04
+# See https://snapcraft.io/docs/build-on-docker
 
-RUN apt-get update -y && apt-get install -y \
-    binutils \
-    curl \
-    snapcraft \
-    unzip
+FROM ubuntu:bionic as builder
+
+# Grab dependencies
+RUN apt update
+RUN apt dist-upgrade --yes
+RUN apt install --yes \
+      curl \
+      sudo \
+      jq \
+      squashfs-tools
+
+# Grab the core snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
+RUN mkdir -p /snap/core
+RUN unsquashfs -d /snap/core/current core.snap
+
+# Grab the core18 snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
+RUN mkdir -p /snap/core18
+RUN unsquashfs -d /snap/core18/current core18.snap
+
+# Grab the snapcraft snap from the stable channel and unpack it in the proper place
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
+RUN mkdir -p /snap/snapcraft
+RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
+
+# Create a snapcraft runner
+RUN mkdir -p /snap/bin
+RUN echo "#!/bin/sh" > /snap/bin/snapcraft
+RUN snap_version="$(awk '/^version:/{print $2}' /snap/snapcraft/current/meta/snap.yaml)" && echo "export SNAP_VERSION=\"$snap_version\"" >> /snap/bin/snapcraft
+RUN echo 'exec "$SNAP/usr/bin/python3" "$SNAP/bin/snapcraft" "$@"' >> /snap/bin/snapcraft
+RUN chmod +x /snap/bin/snapcraft
+
+# Multi-stage build, only need the snaps from the builder. Copy them one at a
+# time so they can be cached.
+FROM ubuntu:bionic
+COPY --from=builder /snap/core /snap/core
+COPY --from=builder /snap/core18 /snap/core18
+COPY --from=builder /snap/snapcraft /snap/snapcraft
+COPY --from=builder /snap/bin/snapcraft /snap/bin/snapcraft
+
+# Generate locale and add required packages/PPAs
+RUN apt update && apt dist-upgrade --yes && apt install --yes sudo snapd locales && locale-gen en_US.UTF-8 && \
+    apt-get install -y binutils curl unzip software-properties-common && \
+    add-apt-repository ppa:beineri/opt-qt-5.12.10-bionic
+
+# Set the proper environment
+ENV LANG="en_US.UTF-8"
+ENV LANGUAGE="en_US:en"
+ENV LC_ALL="en_US.UTF-8"
+ENV PATH="/snap/bin:$PATH"
+ENV SNAP="/snap/snapcraft/current"
+ENV SNAP_NAME="snapcraft"
+ENV SNAP_ARCH="amd64"


### PR DESCRIPTION
Changes the Dockerfile to follow the instructions from `https://snapcraft.io/docs/build-on-docker` (this gives us snapcraft 3, which has the required plugins for dealing with GTK/Qt applications more easily).

Annoying it seems they don't publish an official image for bionic core18 builds (yet) and make us adapt their Dockerfile instead.
